### PR TITLE
Use lexical-binding to prevent Emacs 30 warning & other small optimizations.

### DIFF
--- a/strace-mode.el
+++ b/strace-mode.el
@@ -1,4 +1,4 @@
-;;; strace-mode.el --- strace output syntax highlighting
+;;; strace-mode.el --- strace output syntax highlighting. -*-lexical-binding: t-*-
 
 ;; Copyright © 2016, by Preston Moore
 
@@ -30,28 +30,27 @@
 
 ;; create the list for font-lock.
 ;; each category of keyword is given a particular face
-(defvar strace-font-lock-keywords)
-(setq strace-font-lock-keywords `(
-                                  ("^\\([0-9]+\\) " . (1 font-lock-warning-face))
-                                  ("^[0-9]+ \\([a-zA-Z0-9_]*\\)(" . (1 font-lock-constant-face))
-                                  (" = 0x[[:xdigit:]]+ \\([[:upper:]]+\\).*$" . (1 font-lock-warning-face))
-                                  (" = -?[[:digit:]?]+ \\([[:upper:]]+\\).*$" . (1 font-lock-warning-face))
-                                  (" = \\(0x[[:xdigit:]]+\\).*$" . (1 font-lock-keyword-face))
-                                  (" = \\(-?[[:digit:]?]+\\).*$" . (1 font-lock-keyword-face))
-                                  ("[ =\(\[\{]\\([[:upper:]_|]+\\)[] |\,\(\)\}]" . (1 font-lock-constant-face))
-                                  (" \\((.*)\\)$" . (1 font-lock-comment-face))
-                                  ("\\(/\\*.*\\*/\\)" . (1 font-lock-comment-face))
-                                  ("0x[[:xdigit:]]+" . font-lock-type-face)
-                                  ("-?[[:digit:]]+" . font-lock-type-face)
-                                  )
-)
+(defconst strace-font-lock-keywords
+  '(
+    ("^\\([0-9]+\\) " . (1 font-lock-warning-face))
+    ("^[0-9]+ \\([a-zA-Z0-9_]*\\)(" . (1 font-lock-constant-face))
+    (" = 0x[[:xdigit:]]+ \\([[:upper:]]+\\).*$" . (1 font-lock-warning-face))
+    (" = -?[[:digit:]?]+ \\([[:upper:]]+\\).*$" . (1 font-lock-warning-face))
+    (" = \\(0x[[:xdigit:]]+\\).*$" . (1 font-lock-keyword-face))
+    (" = \\(-?[[:digit:]?]+\\).*$" . (1 font-lock-keyword-face))
+    ("[ =([{]\\([[:upper:]_|]+\\)[] |,()}]" . (1 font-lock-constant-face))
+    (" \\((.*)\\)$" . (1 font-lock-comment-face))
+    ("\\(/\\*.*\\*/\\)" . (1 font-lock-comment-face))
+    ("0x[[:xdigit:]]+" . font-lock-type-face)
+    ("-?[[:digit:]]+" . font-lock-type-face)
+    )
+  "Alist of strace keywords each with a particular face.")
 
 ;;;###autoload
 (define-derived-mode strace-mode fundamental-mode
   "strace"
   "Major mode for strace output."
-  (setq font-lock-defaults '((strace-font-lock-keywords)))
-)
+  (setq font-lock-defaults '((strace-font-lock-keywords))))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.strace\\'" . strace-mode))


### PR DESCRIPTION
Also simplified:
- use defconst instead of defvar with setq,
- use quote instead of back-quote for the alist; there's no non-constant or splice inside the form.
- remove non-required backslash in front of non-meta characters in the regexp for font-lock-constant-face.

Note: this differs from what's proposed by wigust in a different PR:
-  It keeps deriving strace-mode from the fundamental-mode instead of changing to special-mode; a writable buffer does not change to read-only because we change to strace-mode.  This way, as it was originally, a strace output stored into a file can be edited if needed.
